### PR TITLE
Prepare migration data from indexed data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ index-block: build-index-archival
 #	@${BIN} indexer --block 79373253
 #	@${BIN} indexer --block 79377726
 #	@${BIN} indexer --block 80733632
-	@${BIN} indexer --block 82129108
+	@${BIN} indexer --block 82153326
 
 index-latest: build-index
 	@${BIN}  indexer 

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,10 @@ run: build-mainnet-release
 	@${BIN} --features mainnet --release
 	
 migrate-testnet: build-testnet-release
-	@${BIN} migrate --account ${ACCOUNT_ID} --key ${ACCOUNT_KEY}  --file contract_state.borsh
+	@${BIN} migrate --account ${ACCOUNT_ID} --key ${ACCOUNT_KEY} --file contract_state.borsh
 
 migrate-testnet-indexed: build-testnet-release
-	@${BIN} migrate --account ${ACCOUNT_ID} --key ${ACCOUNT_KEY}  --file for-migtation.borsh
+	@${BIN} migrate --account ${ACCOUNT_ID} --key ${ACCOUNT_KEY} --file for-migtation.borsh
 
 build-index-archival:
 	@cargo build --release --features mainnet-archival
@@ -34,17 +34,16 @@ index-block: build-index-archival
 	@${BIN} indexer --block 82153326
 
 index-latest: build-index
-	@${BIN}  indexer 
+	@${BIN} indexer 
 
 index-history: build-index
-	@${BIN}  indexer -H
+	@${BIN} indexer -H
 	
 index-stat: build-index
-	@${BIN}  indexer --stat
+	@${BIN} indexer --stat
 	
 index-fullstat: build-index
-	@${BIN}  indexer --fullstat
+	@${BIN} indexer --fullstat
 	
 prepare-migration: build-index
-	@${BIN} prepare-migrate-indexed -f  data.borsh -o for-migtation.borsh
-	
+	@${BIN} prepare-migrate-indexed -f data.borsh -o for-migtation.borsh

--- a/Makefile
+++ b/Makefile
@@ -18,13 +18,17 @@ run: build-mainnet-release
 migrate-testnet: build-testnet-release
 	@${BIN} migrate --account ${ACCOUNT_ID} --key ${ACCOUNT_KEY}  --file contract_state.borsh
 
-build-index:
+build-index-archival:
 	@cargo build --release --features mainnet-archival
+
+build-index:
+	@cargo build --release --features mainnet
 	
-index: build-index
+index-block: build-index-archival
 #	@${BIN} indexer --block 79373253
 #	@${BIN} indexer --block 79377726
-	@${BIN} indexer --block 80733632
+#	@${BIN} indexer --block 80733632
+	@${BIN} indexer --block 82128665
 
 index-latest: build-index
 	@${BIN}  indexer 

--- a/Makefile
+++ b/Makefile
@@ -37,3 +37,7 @@ index-stat: build-index
 	
 index-fullstat: build-index
 	@${BIN}  indexer --fullstat
+	
+prepare-migration: build-index
+	@${BIN} prepare-migrate-indexed -f  data.borsh -o for-migtation.borsh
+	

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ run: build-mainnet-release
 migrate-testnet: build-testnet-release
 	@${BIN} migrate --account ${ACCOUNT_ID} --key ${ACCOUNT_KEY}  --file contract_state.borsh
 
+migrate-testnet-indexed: build-testnet-release
+	@${BIN} migrate --account ${ACCOUNT_ID} --key ${ACCOUNT_KEY}  --file for-migtation.borsh
+
 build-index-archival:
 	@cargo build --release --features mainnet-archival
 
@@ -28,7 +31,7 @@ index-block: build-index-archival
 #	@${BIN} indexer --block 79373253
 #	@${BIN} indexer --block 79377726
 #	@${BIN} indexer --block 80733632
-	@${BIN} indexer --block 82128665
+	@${BIN} indexer --block 82129108
 
 index-latest: build-index
 	@${BIN}  indexer 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -54,20 +54,21 @@ impl Indexer {
 
     pub fn stats(&self, extend: bool) {
         let data = self.data.lock().unwrap();
-        println!("First block: {:?}", data.first_block);
-        println!("Last block: {:?}", data.last_block);
-        println!("Current block: {:?}", data.current_block);
-        println!(
-            "Missed block: [{:?}] {:?}",
-            data.missed_blocks.len(),
-            data.missed_blocks
-        );
-        println!("Accounts: {:?}", data.data.accounts.len());
-        println!("Proofs: {:?}", data.data.proofs.len());
 
         if extend {
-            println!("Log: {:#?}", data.data.logs);
+            println!("Logs: {:#?}\n", data.data.logs);
+            println!(
+                "Missed block list: [{}] {:?}\n",
+                data.missed_blocks.len(),
+                data.missed_blocks
+            );
         }
+        println!(r#"First block: {:?}"#, data.first_block);
+        println!("Last block: {:?}", data.last_block);
+        println!("Current block: {:?}", data.current_block);
+        println!("Missed blocks: {}", data.missed_blocks.len());
+        println!("Accounts: {}", data.data.accounts.len());
+        println!("Proofs: {}", data.data.proofs.len());
     }
 
     /// Save indexed data

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -133,6 +133,7 @@ impl Indexer {
         }
     }
 
+    /// Handle fetching blocks
     async fn handle_block(
         &mut self,
         block: (BlockHeight, Vec<ChunkHeaderView>),

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1,9 +1,10 @@
-use crate::rpc::{BlockKind, IndexedData, RPC};
+use crate::rpc::{BlockKind, Client, IndexedData};
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_primitives::types::BlockHeight;
+use near_primitives::views::ChunkHeaderView;
 use std::collections::HashSet;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::time::Instant;
@@ -29,21 +30,26 @@ pub struct Indexer {
 
 impl Indexer {
     /// Init new indexer
-    pub fn new(data_file: PathBuf, fetch_history: bool, block_height: Option<BlockHeight>) -> Self {
+    pub fn new<P: AsRef<Path>>(
+        data_file: P,
+        fetch_history: bool,
+        block_height: Option<BlockHeight>,
+    ) -> anyhow::Result<Self> {
         // If file doesn't exist just return default data
         let data = std::fs::read(&data_file).unwrap_or_default();
-        let mut data: IndexerData = IndexerData::try_from_slice(&data[..]).unwrap_or_default();
+        let mut data = IndexerData::try_from_slice(&data).unwrap_or_default();
 
         if let Some(height) = block_height {
             data.last_block = height - 1;
         }
-        Self {
+
+        Ok(Self {
             data: Arc::new(Mutex::new(data)),
-            data_file,
+            data_file: data_file.as_ref().to_path_buf(),
             last_saved_time: Instant::now(),
             fetch_history,
             force_index_from_block: block_height,
-        }
+        })
     }
 
     pub fn stats(&self, extend: bool) {
@@ -58,16 +64,21 @@ impl Indexer {
         );
         println!("Accounts: {:?}", data.data.accounts.len());
         println!("Proofs: {:?}", data.data.proofs.len());
+
         if extend {
             println!("Log: {:#?}", data.data.logs);
         }
     }
 
     /// Save indexed data
-    fn save_data(data: IndexerData, data_file: &PathBuf, current_block_height: BlockHeight) {
+    fn save_data<P: AsRef<Path>>(
+        data: &IndexerData,
+        data_file: P,
+        current_block_height: BlockHeight,
+    ) {
         std::fs::write(data_file, data.try_to_vec().expect("Failed serialize"))
             .expect("Failed save indexed data");
-        println!(" [SAVE: {:?}]", current_block_height);
+        println!("[SAVE: {:?}]", current_block_height);
     }
 
     /// Set current index data
@@ -97,62 +108,81 @@ impl Indexer {
 
     /// Run indexing
     pub async fn run(&mut self) -> anyhow::Result<()> {
-        let mut rpc = RPC::new().await?;
-        let missed_blocks = { self.data.lock().unwrap().missed_blocks.clone() };
-        rpc.set_missed_blocks(missed_blocks);
-        let last_block = { self.data.lock().unwrap().last_block };
-        println!("Starting height: {:?}", last_block);
+        let mut client = Client::new();
+        let missed_blocks = self.data.lock().unwrap().missed_blocks.clone();
+        client.set_missed_blocks(missed_blocks);
+        let last_block = self.data.lock().unwrap().last_block;
+        println!("Starting height: {}", last_block);
+        let mut handle = None;
 
         loop {
-            let current_block = if let Ok(block) = rpc.get_block(BlockKind::Latest).await {
-                block
-            } else {
-                // Do not fail
-                continue;
-            };
-            let last_block = { self.data.lock().unwrap().last_block };
-            // Skip, if block already exists
-            if last_block >= current_block.0 {
-                continue;
+            tokio::select! {
+                block = client.get_block(BlockKind::Latest) => if let Ok(block) = block {
+                    handle = self.handle_block(block, &mut client).await;
+                },
+                _ = tokio::signal::ctrl_c() => break,
+                else => break,
             }
-            // Check, do we need fetch history data or force check from some block height
-            let (height, chunks) = if self.force_index_from_block.is_some() || self.fetch_history {
-                if current_block.0 - last_block > 0 {
-                    if let Ok(block) = rpc.get_block(BlockKind::Height(last_block + 1)).await {
-                        block
-                    } else {
-                        // If block not found do not fail, just increment height
-                        let mut data = self.data.lock().unwrap();
-                        data.last_block = last_block + 1;
-                        continue;
-                    }
+        }
+
+        // Wait for data saving
+        if let Some(handle) = handle {
+            handle.await.map_err(Into::into)
+        } else {
+            Ok(())
+        }
+    }
+
+    async fn handle_block(
+        &mut self,
+        block: (BlockHeight, Vec<ChunkHeaderView>),
+        client: &mut Client,
+    ) -> Option<tokio::task::JoinHandle<()>> {
+        let last_block = self.data.lock().unwrap().last_block;
+        // Skip, if block already exists
+        if last_block >= block.0 {
+            return None;
+        }
+        // Check, do we need fetch history data or force check from some block height
+        let (height, chunks) = if self.force_index_from_block.is_some() || self.fetch_history {
+            if block.0 - last_block > 0 {
+                if let Ok(block) = client.get_block(BlockKind::Height(last_block + 1)).await {
+                    block
                 } else {
-                    current_block.clone()
+                    // If block not found do not fail, just increment height
+                    let mut data = self.data.lock().unwrap();
+                    data.last_block = last_block + 1;
+                    return None;
                 }
             } else {
-                current_block.clone()
-            };
-            print!("\rHeight: {:?}", height);
-            std::io::stdout().flush().expect("Flush failed");
-
-            let indexed_data = rpc.get_chunk_indexed_data(chunks, height).await;
-            self.set_indexed_data(
-                height,
-                indexed_data,
-                rpc.unresolved_blocks.clone(),
-                current_block.0,
-            );
-
-            // Save data
-            if self.last_saved_time.elapsed() > SAVE_FILE_TIMEOUT {
-                self.last_saved_time = Instant::now();
-                let current_block_height = current_block.0;
-                let data_file = self.data_file.clone();
-                let data = self.data.lock().unwrap().clone();
-                tokio::spawn(async move {
-                    Self::save_data(data, &data_file, current_block_height);
-                });
+                block.clone()
             }
+        } else {
+            block.clone()
+        };
+        print!("\rHeight: {:?}", height);
+        std::io::stdout().flush().expect("Flush failed");
+
+        let indexed_data = client.get_chunk_indexed_data(chunks, height).await;
+        self.set_indexed_data(
+            height,
+            indexed_data,
+            client.unresolved_blocks.clone(),
+            block.0,
+        );
+
+        // Save data
+        if self.last_saved_time.elapsed() > SAVE_FILE_TIMEOUT {
+            self.last_saved_time = Instant::now();
+            let current_block_height = block.0;
+            let data_file = self.data_file.clone();
+            let data = self.data.lock().unwrap().clone();
+
+            Some(tokio::spawn(async move {
+                Self::save_data(&data, &data_file, current_block_height);
+            }))
+        } else {
+            None
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,22 +88,23 @@ async fn main() -> anyhow::Result<()> {
         Some(("parse", cmd)) => {
             let snapshot_json_file = cmd
                 .get_one::<PathBuf>("file")
-                .expect("Expected snapshot file");
+                .ok_or_else(|| anyhow::anyhow!("Expected snapshot file"))?;
             let output = cmd.get_one::<PathBuf>("output");
-            parser::parse(snapshot_json_file, output.cloned());
+            parser::parse(snapshot_json_file, output)?;
         }
         Some(("indexer", cmd)) => {
             let history = cmd.get_flag("history");
             let stat = cmd.get_flag("stat");
             let fullstat = cmd.get_flag("fullstat");
             let block = cmd.get_one::<u64>("block").copied();
-            let mut indexer = Indexer::new("data.borsh".into(), history, block);
+            let mut indexer = Indexer::new("data.borsh", history, block)?;
+
             if stat {
                 indexer.stats(false);
             } else if fullstat {
                 indexer.stats(true);
             } else {
-                indexer.run().await?
+                indexer.run().await?;
             }
         }
         Some(("migrate", cmd)) => {
@@ -114,8 +115,7 @@ async fn main() -> anyhow::Result<()> {
                 .expect("Expected account-id");
             let account_key = cmd.get_one::<String>("key").expect("Expected account-key");
 
-            Migration::new(data_file, account_id.clone(), account_key.clone())
-                .await?
+            Migration::new(data_file, account_id.clone(), account_key.clone())?
                 .run()
                 .await?;
         }

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -273,6 +273,16 @@ impl Migration {
             .await?;
         migration_data.accounts_counter = U64::try_from_slice(&data).unwrap().0;
 
+        let data = rpc
+            .request_view(
+                AURORA_CONTRACT.to_string(),
+                "ft_total_supply".to_string(),
+                vec![],
+            )
+            .await?;
+        let total_supply: U128 = serde_json::from_slice(&data).unwrap();
+        migration_data.contract_data.total_eth_supply_on_near = NEP141Wei::new(total_supply.0);
+
         for account in indexer_data.data.accounts {
             let args = json!({ "account_id": account })
                 .to_string()
@@ -299,7 +309,6 @@ impl Migration {
             migration_data.proofs.push(proof);
         }
 
-        // get_accounts_counter
         // ft_total_supply
         // storage_balance_of
 
@@ -312,6 +321,10 @@ impl Migration {
         println!("Proofs: {:?}", migration_data.proofs.len());
         println!("Accounts: {:?}", migration_data.accounts.len());
         println!("Accounts counter: {:?}", migration_data.accounts_counter);
+        println!(
+            "Total supply: {:?}",
+            migration_data.contract_data.total_eth_supply_on_near
+        );
         Ok(())
     }
 }

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -25,7 +25,7 @@ pub struct Migration {
     pub config: MigrationConfig,
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[derive(Debug, BorshDeserialize, BorshSerialize)]
 pub struct MigrationInputData {
     pub accounts: HashMap<AccountId, Balance>,
     pub total_supply: Option<Balance>,
@@ -169,6 +169,7 @@ impl Migration {
             i += limit;
         }
         assert_eq!(proofs_count, self.data.proofs.len());
+        println!();
 
         // Accounts migration
         let mut accounts: HashMap<AccountId, Balance> = HashMap::new();
@@ -221,7 +222,7 @@ impl Migration {
         // Checking the correctness and integrity of data, regardless of
         // the migration process
 
-        println!();
+        println!("\n\n[Check correctness]");
         for (migration_data, counter) in reproducible_data_for_proofs {
             self.check_migration("Proofs", migration_data, counter)
                 .await?;
@@ -237,6 +238,7 @@ impl Migration {
         self.check_migration("Contract data:", contract_migration_data, 1)
             .await?;
 
+        println!();
         Ok(())
     }
 

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -256,6 +256,7 @@ impl Migration {
             contract_data: FungibleToken {
                 total_eth_supply_on_near: NEP141Wei::new(0),
                 total_eth_supply_on_aurora: NEP141Wei::new(0),
+                // This value impossible to request from the contract
                 account_storage_usage: 0,
             },
             accounts: HashMap::new(),
@@ -274,18 +275,6 @@ impl Migration {
         let total_supply: U128 = serde_json::from_slice(&data).unwrap();
         migration_data.contract_data.total_eth_supply_on_near = NEP141Wei::new(total_supply.0);
 
-        let args = json!({ "account_id": crate::rpc::AURORA_CONTRACT })
-            .to_string()
-            .as_bytes()
-            .to_vec();
-        let data = rpc
-            .request_view(AURORA_CONTRACT, "storage_balance_of".to_string(), args)
-            .await?;
-
-        let x: U64 = serde_json::from_slice(&data).unwrap();
-
-        migration_data.contract_data.account_storage_usage = serde_json::from_slice(&data).unwrap();
-        println!("#6");
         for account in indexer_data.data.accounts {
             let args = json!({ "account_id": account })
                 .to_string()
@@ -313,7 +302,10 @@ impl Migration {
         println!("Accounts counter: {:?}", migration_data.accounts_counter);
         println!(
             "Total supply: {:?}",
-            migration_data.contract_data.total_eth_supply_on_near
+            migration_data
+                .contract_data
+                .total_eth_supply_on_near
+                .as_u128()
         );
 
         migration_data

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -274,11 +274,18 @@ impl Migration {
         let total_supply: U128 = serde_json::from_slice(&data).unwrap();
         migration_data.contract_data.total_eth_supply_on_near = NEP141Wei::new(total_supply.0);
 
+        let args = json!({ "account_id": crate::rpc::AURORA_CONTRACT })
+            .to_string()
+            .as_bytes()
+            .to_vec();
         let data = rpc
-            .request_view(AURORA_CONTRACT, "storage_balance_of".to_string(), vec![])
+            .request_view(AURORA_CONTRACT, "storage_balance_of".to_string(), args)
             .await?;
-        migration_data.contract_data.account_storage_usage = serde_json::from_slice(&data).unwrap();
 
+        let x: U64 = serde_json::from_slice(&data).unwrap();
+
+        migration_data.contract_data.account_storage_usage = serde_json::from_slice(&data).unwrap();
+        println!("#6");
         for account in indexer_data.data.accounts {
             let args = json!({ "account_id": account })
                 .to_string()

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,27 +4,34 @@ use aurora_engine_types::storage::{EthConnectorStorageId, KeyPrefix, VersionPref
 use aurora_engine_types::types::NEP141Wei;
 use borsh::{BorshDeserialize, BorshSerialize};
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+enum KeyType {
+    Accounts(Vec<u8>),
+    Contract,
+    Proof(Vec<u8>),
+    Statistic,
+    Unknown,
+}
 
 pub fn bytes_to_key(prefix: KeyPrefix, bytes: &[u8]) -> Vec<u8> {
     [&[u8::from(VersionPrefix::V1)], &[u8::from(prefix)], bytes].concat()
 }
 
-pub fn construct_contract_key(suffix: &EthConnectorStorageId) -> Vec<u8> {
-    bytes_to_key(KeyPrefix::EthConnector, &[u8::from(*suffix)])
+pub fn construct_contract_key(suffix: EthConnectorStorageId) -> Vec<u8> {
+    bytes_to_key(KeyPrefix::EthConnector, &[u8::from(suffix)])
 }
 
 pub fn read_u64(value: &[u8]) -> u64 {
-    if value.len() != 8 {
-        panic!("Failed parse u64")
-    }
+    assert_eq!(value.len(), 8, "Failed parse u64");
+
     let mut result = [0u8; 8];
     result.copy_from_slice(value.as_ref());
     u64::from_le_bytes(result)
 }
 
 pub fn prefix_proof_key() -> Vec<u8> {
-    construct_contract_key(&EthConnectorStorageId::UsedEvent)
+    construct_contract_key(EthConnectorStorageId::UsedEvent)
 }
 
 pub fn prefix_account_key() -> Vec<u8> {
@@ -44,68 +51,65 @@ pub fn get_statistic_key() -> Vec<u8> {
 }
 
 pub fn get_contract_key() -> Vec<u8> {
-    construct_contract_key(&EthConnectorStorageId::FungibleToken)
+    construct_contract_key(EthConnectorStorageId::FungibleToken)
 }
 
-pub fn parse(json_file: &PathBuf, output: Option<PathBuf>) {
-    let data = std::fs::read_to_string(json_file).expect("Failed read data");
-    let json_data: BlockData = serde_json::from_str(&data).expect("Failed read json");
-    let result_file_name: PathBuf = if let Some(output) = output {
-        output
-    } else {
-        use std::str::FromStr;
-
-        PathBuf::from_str(&format!(
-            "contract_state{:?}.borsh",
-            json_data.result.block_height
-        ))
-        .expect("Failed parse output result file")
-    };
+pub fn parse<P: AsRef<Path>>(json_file: P, output: Option<P>) -> anyhow::Result<()> {
+    let data =
+        std::fs::read_to_string(json_file).map_err(|e| anyhow::anyhow!("Failed read data: {e}"))?;
+    let json_data: BlockData =
+        serde_json::from_str(&data).map_err(|e| anyhow::anyhow!("Failed read json: {e}"))?;
+    let result_file_name = output.map_or_else(
+        || {
+            PathBuf::from(format!(
+                "contract_state{}.borsh",
+                json_data.result.block_height
+            ))
+        },
+        |p| p.as_ref().to_path_buf(),
+    );
 
     println!("Block height: {:?}", json_data.result.block_height);
     println!("Data size: {:.3} Gb", data.len() as f64 / 1_000_000_000.);
     println!("Data values: {:#?}", json_data.result.values.len());
 
-    let proof_prefix = &prefix_proof_key()[..];
-    let account_prefix = &prefix_account_key()[..];
-    let account_counter_key = &get_statistic_key()[..];
     let mut proofs: Vec<String> = vec![];
     let mut accounts: HashMap<AccountId, NEP141Wei> = HashMap::new();
     let mut accounts_counter: u64 = 0;
     let mut contract_data: FungibleToken = FungibleToken::default();
-    for value in &json_data.result.values {
-        let key = base64::decode(&value.key).expect("Failed deserialize key");
+
+    for result_value in &json_data.result.values {
+        let key = base64::decode(&result_value.key)
+            .map_err(|e| anyhow::anyhow!("Failed deserialize key, {e}"))?;
         // Get proofs
-        if key.len() > proof_prefix.len() && &key[..proof_prefix.len()] == proof_prefix {
-            let val = key[proof_prefix.len()..].to_vec();
-            let proof = String::from_utf8(val).expect("Failed parse proof");
-            proofs.push(proof);
-            continue;
-        }
-        // Get accounts
-        if key.len() > account_prefix.len() && &key[..account_prefix.len()] == account_prefix {
-            let val = key[account_prefix.len()..].to_vec();
-            let account =
-                AccountId::try_from(String::from_utf8(val).expect("Failed parse account"))
-                    .expect("Failed parse account");
-            let account_balance = NEP141Wei::try_from_slice(
-                &base64::decode(&value.value).expect("Failed get account balance")[..],
-            )
-            .expect("Failed parse account balance");
-            accounts.insert(account, account_balance);
-            continue;
-        }
-        // Account statistics
-        if key == account_counter_key {
-            let val = base64::decode(&value.value).expect("Failed get account counter");
-            accounts_counter = read_u64(&val[..]);
-            continue;
-        }
-        // Get contract data
-        if key == get_contract_key() {
-            let val = &base64::decode(&value.value).expect("Failed get contract data")[..];
-            contract_data = FungibleToken::try_from_slice(val).expect("Failed parse contract data");
-            continue;
+        match key_type(&key) {
+            KeyType::Proof(value) => {
+                let proof = String::from_utf8(value)
+                    .map_err(|e| anyhow::anyhow!("Failed parse proof, {e}"))?;
+                proofs.push(proof);
+            }
+            KeyType::Accounts(value) => {
+                let account = AccountId::try_from(value.as_slice())
+                    .map_err(|e| anyhow::anyhow!("Failed parse account, {e}"))?;
+                let account_balance = NEP141Wei::try_from_slice(
+                    &base64::decode(&result_value.value)
+                        .map_err(|e| anyhow::anyhow!("Failed get account balance, {e}"))?,
+                )
+                .map_err(|e| anyhow::anyhow!("Failed parse account balance, {e}"))?;
+                accounts.insert(account, account_balance);
+            }
+            KeyType::Contract => {
+                let val = base64::decode(&result_value.value)
+                    .map_err(|e| anyhow::anyhow!("Failed get contract data, {e}"))?;
+                contract_data = FungibleToken::try_from_slice(&val)
+                    .map_err(|e| anyhow::anyhow!("Failed parse contract data, {e}"))?;
+            }
+            KeyType::Statistic => {
+                let val = base64::decode(&result_value.value)
+                    .map_err(|e| anyhow::anyhow!("Failed get account counter, {e}"))?;
+                accounts_counter = read_u64(&val);
+            }
+            KeyType::Unknown => anyhow::bail!("Unknown key type"),
         }
     }
     println!("Proofs: {:?}", proofs.len());
@@ -116,15 +120,42 @@ pub fn parse(json_file: &PathBuf, output: Option<PathBuf>) {
         "Wrong accounts count"
     );
     // Store result data
-    let data = StateData {
+    println!("Result file: {:?}", result_file_name);
+    StateData {
         contract_data,
         accounts,
         accounts_counter,
         proofs,
     }
     .try_to_vec()
-    .expect("Failed serialize data");
+    .and_then(|data| std::fs::write(result_file_name, data))
+    .map_err(|e| anyhow::anyhow!("Failed save result data, {e}"))
+}
 
-    println!("Result file: {:?}", result_file_name);
-    std::fs::write(result_file_name, data).expect("Failed save result data");
+fn key_type(key: &[u8]) -> KeyType {
+    if is_prefix_proof_key(key) {
+        let proof_prefix_len = prefix_proof_key().len();
+        let value = key[proof_prefix_len..].to_vec();
+        KeyType::Proof(value)
+    } else if is_account_prefix_key(key) {
+        let account_prefix_len = prefix_account_key().len();
+        let value = key[account_prefix_len..].to_vec();
+        KeyType::Accounts(value)
+    } else if key == get_contract_key() {
+        KeyType::Contract
+    } else if key == get_statistic_key() {
+        KeyType::Statistic
+    } else {
+        KeyType::Unknown
+    }
+}
+
+fn is_prefix_proof_key(key: &[u8]) -> bool {
+    let proof_prefix = &prefix_proof_key();
+    key.len() > proof_prefix.len() && &key[..proof_prefix.len()] == proof_prefix
+}
+
+fn is_account_prefix_key(key: &[u8]) -> bool {
+    let account_prefix = &prefix_account_key();
+    key.len() > account_prefix.len() && &key[..account_prefix.len()] == account_prefix
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -112,8 +112,8 @@ pub fn parse<P: AsRef<Path>>(json_file: P, output: Option<P>) -> anyhow::Result<
             KeyType::Unknown => anyhow::bail!("Unknown key type"),
         }
     }
-    println!("Proofs: {:?}", proofs.len());
-    println!("Accounts: {:?}", accounts.len());
+    println!("Proofs: {}", proofs.len());
+    println!("Accounts: {}", accounts.len());
     assert_eq!(
         accounts.len() as u64,
         accounts_counter,

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -124,10 +124,12 @@ impl Client {
             .call(methods::block::RpcBlockRequest { block_reference })
             .await
             .map_err(|e| {
-                print_log("Failed get block");
+                let mut msg = "Failed get block".to_string();
                 if let BlockKind::Height(height) = bloch_kind {
                     self.unresolved_blocks.insert(height);
+                    msg = format!("{}: {:?}", msg.clone(), height);
                 }
+                print_log(&msg);
                 e
             })?;
 

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -23,7 +23,7 @@ const NEAR_RPC_ADDRESS: &str = near_jsonrpc_client::NEAR_MAINNET_ARCHIVAL_RPC_UR
 const NEAR_RPC_ADDRESS: &str = near_jsonrpc_client::NEAR_TESTNET_RPC_URL;
 
 /// NEAR-RPC has limits: 600 req/sec, so we need timeout per requests
-const REQUEST_TIMEOUT: Duration = Duration::from_millis(90);
+pub const REQUEST_TIMEOUT: Duration = Duration::from_millis(90);
 
 /// Gas for commit tx to blockchain (300 `TGas`)
 const GAS_FOR_COMMIT_TX: u64 = 300_000_000_000_000;

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -23,9 +23,9 @@ const NEAR_RPC_ADDRESS: &str = near_jsonrpc_client::NEAR_MAINNET_ARCHIVAL_RPC_UR
 const NEAR_RPC_ADDRESS: &str = near_jsonrpc_client::NEAR_TESTNET_RPC_URL;
 
 /// NEAR-RPC has limits: 600 req/sec, so we need timeout per requests
-pub const REQUEST_TIMEOUT: Duration = Duration::from_millis(90);
+const REQUEST_TIMEOUT: Duration = Duration::from_millis(90);
 
-/// Gas for commit tx to blockchain (300 TGas)
+/// Gas for commit tx to blockchain (300 `TGas`)
 const GAS_FOR_COMMIT_TX: u64 = 300_000_000_000_000;
 
 /// Transactions receiver
@@ -43,10 +43,10 @@ const ACTION_METHODS: &[&str] = &[
     "finish_deposit",
 ];
 
-pub struct RPC {
+pub struct Client {
     /// NEAR-rpc client
     pub client: JsonRpcClient,
-    /// One possile reason: https://stackoverflow.com/a/72230096
+    /// One possible reason: https://stackoverflow.com/a/72230096
     pub unresolved_blocks: HashSet<BlockHeight>,
 }
 
@@ -83,14 +83,15 @@ pub struct IndexedData {
     pub logs: Vec<IndexedResultLog>,
 }
 
-impl RPC {
+impl Client {
     /// Init RPC with final (latest) flock height
-    pub async fn new() -> anyhow::Result<Self> {
-        Ok(Self {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
             // Init ner-rpc client
             client: JsonRpcClient::connect(NEAR_RPC_ADDRESS),
             unresolved_blocks: HashSet::new(),
-        })
+        }
     }
 
     /// Set missed blocks for RPC runner
@@ -115,13 +116,9 @@ impl RPC {
         bloch_kind: BlockKind,
     ) -> anyhow::Result<(BlockHeight, Vec<ChunkHeaderView>)> {
         let block_reference = if let BlockKind::Height(height) = bloch_kind {
-            near_primitives::types::BlockReference::BlockId(
-                near_primitives::types::BlockId::Height(height),
-            )
+            BlockReference::BlockId(near_primitives::types::BlockId::Height(height))
         } else {
-            near_primitives::types::BlockReference::Finality(
-                near_primitives::types::Finality::Final,
-            )
+            BlockReference::Finality(near_primitives::types::Finality::Final)
         };
         let block = self
             .call(methods::block::RpcBlockRequest { block_reference })
@@ -133,40 +130,36 @@ impl RPC {
                 }
                 e
             })?;
+
         Ok((block.header.height, block.chunks))
     }
 
     /// Get action output for chunk transaction (including receipt output)
     /// It includes: Accounts, Proof keys
     pub fn get_actions_data(&mut self, actions: Vec<ActionView>) -> ActionResult {
-        let mut result = ActionResult {
-            accounts: vec![],
-            proofs: vec![],
-            is_action_found: false,
-            log: vec![],
-        };
+        let mut result = ActionResult::default();
+
         for action in actions {
             // Check action method and filter it
-            let (method_name, args) = match action {
-                ActionView::FunctionCall {
-                    method_name, args, ..
-                } => (method_name, args),
-                _ => continue,
-            };
-            if !ACTION_METHODS.contains(&method_name.as_str()) {
-                continue;
-            }
+            if let ActionView::FunctionCall {
+                method_name, args, ..
+            } = action
+            {
+                if ACTION_METHODS.contains(&method_name.as_str()) {
+                    let (accounts, proof) = self.parse_action_argument(&method_name, &args);
 
-            let mut res = self.parse_action_argument(method_name.clone(), args);
-            result.is_action_found = true;
-            result.log.push(ActionResultLog {
-                accounts: res.0.clone(),
-                proof: res.1.clone().unwrap_or_default(),
-                method: method_name,
-            });
-            result.accounts.append(&mut res.0);
-            if let Some(proof) = res.1 {
-                result.proofs.push(proof);
+                    result.is_action_found = true;
+                    result.log.push(ActionResultLog {
+                        accounts: accounts.clone(),
+                        proof: proof.clone().unwrap_or_default(),
+                        method: method_name,
+                    });
+                    result.accounts.extend(accounts);
+
+                    if let Some(proof) = proof {
+                        result.proofs.push(proof);
+                    }
+                }
             }
         }
 
@@ -174,14 +167,15 @@ impl RPC {
     }
 
     /// Parse action arguments and return accounts and proof keys
+    #[must_use]
     pub fn parse_action_argument(
         &self,
-        method: String,
-        args: Vec<u8>,
+        method: &str,
+        args: &[u8],
     ) -> (Vec<AccountId>, Option<String>) {
         use serde::Deserialize;
 
-        match method.as_str() {
+        match method {
             "ft_transfer" => {
                 #[derive(Debug, Deserialize)]
                 pub struct FtTransferArgs {
@@ -189,7 +183,7 @@ impl RPC {
                     pub amount: U128,
                     pub memo: Option<String>,
                 }
-                if let Ok(res) = serde_json::from_slice::<FtTransferArgs>(&args[..]) {
+                if let Ok(res) = serde_json::from_slice::<FtTransferArgs>(args) {
                     print_log("ft_transfer");
                     (vec![res.receiver_id], None)
                 } else {
@@ -205,8 +199,7 @@ impl RPC {
                     pub memo: Option<String>,
                     pub msg: String,
                 }
-                let _ = serde_json::from_slice::<FtTransferCallArgs>(&args[..]).unwrap();
-                if let Ok(res) = serde_json::from_slice::<FtTransferCallArgs>(&args[..]) {
+                if let Ok(res) = serde_json::from_slice::<FtTransferCallArgs>(args) {
                     print_log("ft_transfer_call");
                     (vec![res.receiver_id], None)
                 } else {
@@ -228,7 +221,7 @@ impl RPC {
                     pub fee: u128,
                     pub msg: Option<Vec<u8>>,
                 }
-                if let Ok(res) = FinishDepositArgs::try_from_slice(&args[..]) {
+                if let Ok(res) = FinishDepositArgs::try_from_slice(args) {
                     print_log("finish_deposit");
                     (vec![res.new_owner_id, res.relayer_id], Some(res.proof_key))
                 } else {
@@ -423,7 +416,7 @@ impl RPC {
                 match tx_res.status {
                     FinalExecutionStatus::SuccessValue(_) => return Ok(()),
                     FinalExecutionStatus::Failure(err) => {
-                        res = Err(CommitTxError::Status(format!("{:?}", err)))
+                        res = Err(CommitTxError::Status(format!("{:?}", err)));
                     }
                     _ => res = Err(CommitTxError::Status("Other".to_string())),
                 }
@@ -433,17 +426,20 @@ impl RPC {
             retry += 1;
             println!("\nRequest retry: {:?}", retry);
             // If all retries failed it's incident, just panic
-            if retry > RETRIES_COUNT {
-                panic!("Failed commit tx {:?} times: {:?}", RETRIES_COUNT, res);
-            }
+            assert!(
+                retry <= RETRIES_COUNT,
+                "Failed commit tx {:?} times: {:?}",
+                RETRIES_COUNT,
+                res
+            );
         }
     }
 
     /// Request view data for contract method.
-    /// Return error if wrong response type or failfViewed request
+    /// Return error if wrong response type or failViewed request
     pub async fn request_view(
         &self,
-        contract: String,
+        contract: &str,
         method: String,
         args: Vec<u8>,
     ) -> anyhow::Result<Vec<u8>> {
@@ -460,17 +456,24 @@ impl RPC {
         let response = self.client.call(request).await?;
         // Response should contain only CallResult, if something other - return error
         if let QueryResponseKind::CallResult(result) = response.kind {
-            return Ok(result.result);
+            Ok(result.result)
+        } else {
+            anyhow::bail!(CommitTxError::View)
         }
-        Err(CommitTxError::View)?
+    }
+}
+
+impl Default for Client {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
 #[allow(dead_code)]
 fn print_log(msg: &str) {
     #[cfg(feature = "log")]
-    // Print witn space shift
-    println!(" {msg}")
+    // Print with space shift
+    println!(" {msg}");
 }
 
 mod error {

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -23,7 +23,7 @@ const NEAR_RPC_ADDRESS: &str = near_jsonrpc_client::NEAR_MAINNET_ARCHIVAL_RPC_UR
 const NEAR_RPC_ADDRESS: &str = near_jsonrpc_client::NEAR_TESTNET_RPC_URL;
 
 /// NEAR-RPC has limits: 600 req/sec, so we need timeout per requests
-const REQUEST_TIMEOUT: Duration = Duration::from_millis(90);
+pub const REQUEST_TIMEOUT: Duration = Duration::from_millis(90);
 
 /// Gas for commit tx to blockchain (300 TGas)
 const GAS_FOR_COMMIT_TX: u64 = 300_000_000_000_000;


### PR DESCRIPTION
After the indexer gathers data, we need to migrate it not the new `aurora-eth-connector` contract.

For that data from the indexer should be prepared for migration and stored as a file for later migration.
