### PR TITLE
Improve migration logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,24 +175,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayref"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
-
-[[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
-
-[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,10 +227,10 @@ dependencies = [
  "base64 0.20.0",
  "clap",
  "libc",
- "near-crypto 0.17.0",
+ "near-crypto",
  "near-jsonrpc-client",
  "near-jsonrpc-primitives",
- "near-primitives 0.17.0",
+ "near-primitives",
  "near-sdk",
  "serde",
  "serde_derive",
@@ -263,7 +245,6 @@ source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.5.0#dc3f
 dependencies = [
  "base64 0.21.5",
  "borsh 0.10.3",
- "borsh 0.9.3",
  "bs58 0.5.0",
  "hex",
  "primitive-types 0.12.2",
@@ -277,12 +258,6 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
-name = "base64"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
 name = "base64"
@@ -313,18 +288,6 @@ name = "bitflags"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
-
-[[package]]
-name = "bitvec"
-version = "0.20.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
 
 [[package]]
 name = "blake2"
@@ -383,7 +346,7 @@ checksum = "6441c552f230375d18e3cc377677914d2ca2b0d36e52129fe15450a2dce46775"
 dependencies = [
  "borsh-derive-internal 0.9.3",
  "borsh-schema-derive-internal 0.9.3",
- "proc-macro-crate 0.1.5",
+ "proc-macro-crate",
  "proc-macro2",
  "syn 1.0.109",
 ]
@@ -396,7 +359,7 @@ checksum = "0754613691538d51f329cce9af41d7b7ca150bc973056f1156611489475f54f7"
 dependencies = [
  "borsh-derive-internal 0.10.3",
  "borsh-schema-derive-internal 0.10.3",
- "proc-macro-crate 0.1.5",
+ "proc-macro-crate",
  "proc-macro2",
  "syn 1.0.109",
 ]
@@ -466,12 +429,6 @@ name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
-
-[[package]]
-name = "byte-slice-cast"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "byteorder"
@@ -870,9 +827,6 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
 dependencies = [
- "byteorder",
- "rand 0.8.5",
- "rustc-hex",
  "static_assertions",
 ]
 
@@ -930,12 +884,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "funty"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
@@ -1265,15 +1213,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "impl-codec"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "161ebdfec3c8e3b52bf61c4f3550a1eea4f9579d10dc1b936f3171ebdcd6c443"
-dependencies = [
- "parity-scale-codec",
-]
-
-[[package]]
 name = "impl-rlp"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1289,17 +1228,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "impl-trait-for-tuples"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1482,16 +1410,6 @@ dependencies = [
 
 [[package]]
 name = "near-account-id"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d258582a1878e6db67400b0504a5099db85718d22c2e07f747fe1706ae7150"
-dependencies = [
- "borsh 0.9.3",
- "serde",
-]
-
-[[package]]
-name = "near-account-id"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0cb40869cab7f5232f934f45db35bffe0f2d2a7cb0cd0346202fbe4ebf2dd7"
@@ -1510,9 +1428,9 @@ dependencies = [
  "chrono",
  "derive_more",
  "near-config-utils",
- "near-crypto 0.17.0",
+ "near-crypto",
  "near-o11y",
- "near-primitives 0.17.0",
+ "near-primitives",
  "num-rational",
  "once_cell",
  "serde",
@@ -1536,32 +1454,6 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e75673d69fd7365508f3d32483669fe45b03bfb34e4d9363e90adae9dfb416c"
-dependencies = [
- "arrayref",
- "blake2",
- "borsh 0.9.3",
- "bs58 0.4.0",
- "c2-chacha",
- "curve25519-dalek",
- "derive_more",
- "ed25519-dalek",
- "near-account-id 0.14.0",
- "once_cell",
- "parity-secp256k1",
- "primitive-types 0.10.1",
- "rand 0.7.3",
- "rand_core 0.5.1",
- "serde",
- "serde_json",
- "subtle",
- "thiserror",
-]
-
-[[package]]
-name = "near-crypto"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff6b382b626e7e0cd372d027c6672ac97b4b6ee6114288c9e58d8180b935d315"
@@ -1574,7 +1466,7 @@ dependencies = [
  "derive_more",
  "ed25519-dalek",
  "hex",
- "near-account-id 0.17.0",
+ "near-account-id",
  "near-config-utils",
  "near-stdx",
  "once_cell",
@@ -1593,7 +1485,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c44c842c6cfcd9b8c387cccd4cd0619a5f21920cde5d5c292af3cc5d40510672"
 dependencies = [
- "near-primitives-core 0.17.0",
+ "near-primitives-core",
 ]
 
 [[package]]
@@ -1606,9 +1498,9 @@ dependencies = [
  "lazy_static",
  "log",
  "near-chain-configs",
- "near-crypto 0.17.0",
+ "near-crypto",
  "near-jsonrpc-primitives",
- "near-primitives 0.17.0",
+ "near-primitives",
  "reqwest",
  "serde",
  "serde_json",
@@ -1623,9 +1515,9 @@ checksum = "97b2934b5ab243e25e951c984525ba0aff0e719ed915c988c5195405aa0f6987"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
- "near-crypto 0.17.0",
- "near-primitives 0.17.0",
- "near-rpc-error-macro 0.17.0",
+ "near-crypto",
+ "near-primitives",
+ "near-rpc-error-macro",
  "serde",
  "serde_json",
  "thiserror",
@@ -1640,8 +1532,8 @@ dependencies = [
  "actix",
  "atty",
  "clap",
- "near-crypto 0.17.0",
- "near-primitives-core 0.17.0",
+ "near-crypto",
+ "near-primitives-core",
  "once_cell",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -1659,35 +1551,6 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad1a9a1640539c81f065425c31bffcfbf6b31ef1aeaade59ce905f5df6ac860"
-dependencies = [
- "borsh 0.9.3",
- "byteorder",
- "bytesize",
- "chrono",
- "derive_more",
- "easy-ext",
- "hex",
- "near-crypto 0.14.0",
- "near-primitives-core 0.14.0",
- "near-rpc-error-macro 0.14.0",
- "near-vm-errors 0.14.0",
- "num-rational",
- "once_cell",
- "primitive-types 0.10.1",
- "rand 0.7.3",
- "reed-solomon-erasure",
- "serde",
- "serde_json",
- "smart-default",
- "strum",
- "thiserror",
-]
-
-[[package]]
-name = "near-primitives"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f7051aaf199adc4d068620fca6d5f70f906a1540d03a8bb3701271f8881835"
@@ -1701,12 +1564,12 @@ dependencies = [
  "easy-ext",
  "enum-map",
  "hex",
- "near-crypto 0.17.0",
+ "near-crypto",
  "near-fmt",
- "near-primitives-core 0.17.0",
- "near-rpc-error-macro 0.17.0",
+ "near-primitives-core",
+ "near-rpc-error-macro",
  "near-stdx",
- "near-vm-errors 0.17.0",
+ "near-vm-errors",
  "num-rational",
  "once_cell",
  "primitive-types 0.10.1",
@@ -1725,23 +1588,6 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d508f0fc340f6461e4e256417685720d3c4c00bb5a939b105160e49137caba"
-dependencies = [
- "base64 0.11.0",
- "borsh 0.9.3",
- "bs58 0.4.0",
- "derive_more",
- "near-account-id 0.14.0",
- "num-rational",
- "serde",
- "sha2 0.10.8",
- "strum",
-]
-
-[[package]]
-name = "near-primitives-core"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775fec19ef51a341abdbf792a9dda5b4cb89f488f681b2fd689b9321d24db47b"
@@ -1752,7 +1598,7 @@ dependencies = [
  "bs58 0.4.0",
  "derive_more",
  "enum-map",
- "near-account-id 0.17.0",
+ "near-account-id",
  "num-rational",
  "serde",
  "serde_repr",
@@ -1760,17 +1606,6 @@ dependencies = [
  "sha2 0.10.8",
  "strum",
  "thiserror",
-]
-
-[[package]]
-name = "near-rpc-error-core"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ee0b41c75ef859c193a8ff1dadfa0c8207bc0ac447cc22259721ad769a1408"
-dependencies = [
- "quote",
- "serde",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1786,23 +1621,12 @@ dependencies = [
 
 [[package]]
 name = "near-rpc-error-macro"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e837bd4bacd807073ec5ceb85708da7f721b46a4c2a978de86027fb0034ce31"
-dependencies = [
- "near-rpc-error-core 0.14.0",
- "serde",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "near-rpc-error-macro"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31d2dadd765101c77e664029dd6fbec090e696877d4ae903c620d02ceda4969a"
 dependencies = [
  "fs2",
- "near-rpc-error-core 0.17.0",
+ "near-rpc-error-core",
  "serde",
  "syn 2.0.42",
 ]
@@ -1810,16 +1634,15 @@ dependencies = [
 [[package]]
 name = "near-sdk"
 version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15eb3de2defe3626260cc209a6cdb985c6b27b0bd4619fad97dcfae002c3c5bd"
+source = "git+https://github.com/aurora-is-near/near-sdk-rs.git?tag=v4.1.1-fix-deps#96afbfa37d1e8b1ecca69dde1d5c715ceeeb3872"
 dependencies = [
  "base64 0.13.1",
- "borsh 0.9.3",
+ "borsh 0.10.3",
  "bs58 0.4.0",
  "near-abi",
- "near-crypto 0.14.0",
- "near-primitives 0.14.0",
- "near-primitives-core 0.14.0",
+ "near-crypto",
+ "near-primitives",
+ "near-primitives-core",
  "near-sdk-macros",
  "near-sys",
  "near-vm-logic",
@@ -1833,8 +1656,7 @@ dependencies = [
 [[package]]
 name = "near-sdk-macros"
 version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4907affc9f5ed559456509188ff0024f1f2099c0830e6bdb66eb61d5b75912c0"
+source = "git+https://github.com/aurora-is-near/near-sdk-rs.git?tag=v4.1.1-fix-deps#96afbfa37d1e8b1ecca69dde1d5c715ceeeb3872"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -1850,21 +1672,8 @@ checksum = "6540152fba5e96fe5d575b79e8cd244cf2add747bb01362426bdc069bc3a23bc"
 
 [[package]]
 name = "near-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397688591acf8d3ebf2c2485ba32d4b24fc10aad5334e3ad8ec0b7179bfdf06b"
-
-[[package]]
-name = "near-vm-errors"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0da466a30f0446639cbd788c30865086fac3e8dcb07a79e51d2b0775ed4261e"
-dependencies = [
- "borsh 0.9.3",
- "near-account-id 0.14.0",
- "near-rpc-error-macro 0.14.0",
- "serde",
-]
+version = "0.2.0"
+source = "git+https://github.com/aurora-is-near/near-sdk-rs.git?tag=v4.1.1-fix-deps#96afbfa37d1e8b1ecca69dde1d5c715ceeeb3872"
 
 [[package]]
 name = "near-vm-errors"
@@ -1873,8 +1682,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec545d1bede0579e7c15dd2dce9b998dc975c52f2165702ff40bec7ff69728bb"
 dependencies = [
  "borsh 0.10.3",
- "near-account-id 0.17.0",
- "near-rpc-error-macro 0.17.0",
+ "near-account-id",
+ "near-rpc-error-macro",
  "serde",
  "strum",
  "thiserror",
@@ -1882,19 +1691,20 @@ dependencies = [
 
 [[package]]
 name = "near-vm-logic"
-version = "0.14.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b534828419bacbf1f7b11ef7b00420f248c548c485d3f0cfda8bb6931152f2"
+checksum = "30d7487c678ed1963a0ecd5033f72bb41caa58debd6fe8025a9bef6e1a6a519a"
 dependencies = [
- "base64 0.13.1",
- "borsh 0.9.3",
- "bs58 0.4.0",
- "byteorder",
- "near-account-id 0.14.0",
- "near-crypto 0.14.0",
- "near-primitives 0.14.0",
- "near-primitives-core 0.14.0",
- "near-vm-errors 0.14.0",
+ "borsh 0.10.3",
+ "ed25519-dalek",
+ "near-account-id",
+ "near-crypto",
+ "near-fmt",
+ "near-o11y",
+ "near-primitives",
+ "near-primitives-core",
+ "near-stdx",
+ "near-vm-errors",
  "ripemd",
  "serde",
  "sha2 0.10.8",
@@ -2076,43 +1886,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
-name = "parity-scale-codec"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373b1a4c1338d9cd3d1fa53b3a11bdab5ab6bd80a20f7f7becd76953ae2be909"
-dependencies = [
- "arrayvec 0.7.4",
- "bitvec",
- "byte-slice-cast",
- "impl-trait-for-tuples",
- "parity-scale-codec-derive",
- "serde",
-]
-
-[[package]]
-name = "parity-scale-codec-derive"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
-dependencies = [
- "proc-macro-crate 1.3.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "parity-secp256k1"
-version = "0.7.0"
-source = "git+https://github.com/paritytech/rust-secp256k1?rev=d05fd8e#d05fd8e152f8d110b587906e3d854196b086e42a"
-dependencies = [
- "arrayvec 0.5.2",
- "cc",
- "cfg-if 0.1.10",
- "rand 0.7.3",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2208,7 +1981,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
 dependencies = [
  "fixed-hash 0.7.0",
- "impl-codec",
  "uint",
 ]
 
@@ -2231,16 +2003,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
  "toml",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
-dependencies = [
- "once_cell",
- "toml_edit",
 ]
 
 [[package]]
@@ -2334,12 +2096,6 @@ checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "radium"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand"
@@ -2959,12 +2715,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
 name = "tempfile"
 version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3147,23 +2897,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
-
-[[package]]
-name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap 2.1.0",
- "toml_datetime",
- "winnow",
 ]
 
 [[package]]
@@ -3727,15 +3460,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
-name = "winnow"
-version = "0.5.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b5c3db89721d50d0e2a673f5043fc4722f76dcc352d7b1ab8b8288bed4ed2c5"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3744,12 +3468,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "wyz"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "zerocopy"
@@ -3804,3 +3522,8 @@ dependencies = [
  "rand 0.8.5",
  "rustc-hex",
 ]
+
+[[patch.unused]]
+name = "parity-secp256k1"
+version = "0.7.0"
+source = "git+https://github.com/paritytech/rust-secp256k1?rev=d05fd8e#d05fd8e152f8d110b587906e3d854196b086e42a"

--- a/README.md
+++ b/README.md
@@ -30,11 +30,9 @@ to the new [aurora-eth-connector](https://github.com/aurora-is-near/aurora-eth-c
 7. Run migration-tool `prepare-for-migration` for parsed Aurora state result data (for ex: `migration_state.borsh`).
 8. Stop migration-tool `indexer`
 9. Run migration-tool `prepare-for-migration` for indexed result data (for ex: `migration_indexed.borsh`).
-10. Run migration-tool `migrate` for previously generated `migration_state.borsh`.
-11. Run migration-tool `migrate` for previously generated `migration_indexed.borsh`.
-12. Run migration-tool `migrate` with check correctness command for `migration_state.borsh`.
-13. Run migration-tool `migrate` with check correctness command for `migration_indexed.borsh`.
-14. Unpause Aurora contract and Bridge.
+10. Run migration-tool `combine-indexed-and-state-data` for indexed and state data (for ex: `migration_indexed.borsh` and `migration_state.borsh`).
+11. Run migration-tool `migrate` for previously generated `migration_full.borsh`.
+12. Unpause Aurora contract and Bridge.
 
 # How it works
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub struct FungibleToken {
 
 #[derive(Debug, Default, BorshSerialize, BorshDeserialize)]
 pub struct StateData {
-    pub contract_data: FungibleToken,
+    pub total_supply: NEP141Wei,
+    pub total_stuck_supply: NEP141Wei,
     pub accounts: HashMap<AccountId, NEP141Wei>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,12 +25,10 @@ pub struct BlockData {
 pub struct FungibleToken {
     pub total_eth_supply_on_near: NEP141Wei,
     pub total_eth_supply_on_aurora: NEP141Wei,
-    pub account_storage_usage: StorageUsage,
 }
 
 #[derive(Debug, Default, BorshSerialize, BorshDeserialize)]
 pub struct StateData {
     pub contract_data: FungibleToken,
     pub accounts: HashMap<AccountId, NEP141Wei>,
-    pub proofs: Vec<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,6 +131,20 @@ async fn main() -> anyhow::Result<()> {
                 .expect("Expected output file");
             Migration::prepare_indexed(input_data_file, output_file).await?;
         }
+        Some(("combine-indexed-and-state-data", cmd)) => {
+            let state_data_file = cmd.get_one::<PathBuf>("state").expect("Expected data file");
+            let indexed_data_file = cmd
+                .get_one::<PathBuf>("indexed")
+                .expect("Expected data file");
+            let output_file = cmd
+                .get_one::<PathBuf>("output")
+                .expect("Expected output file");
+            Migration::combine_indexed_and_state_data(
+                state_data_file,
+                indexed_data_file,
+                output_file,
+            )?;
+        }
         _ => (),
     }
 

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -134,8 +134,9 @@ impl Migration {
 
             reproducible_data_for_accounts.push((accounts.clone(), accounts_count));
 
+            let migration_data: Vec<AccountId> = accounts.keys().cloned().collect();
             self.commit_migration(
-                accounts.try_to_vec().expect("Failed serialize"),
+                migration_data.try_to_vec().expect("Failed serialize"),
                 "Accounts",
                 accounts_count,
             )

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -10,16 +10,11 @@ use std::str::FromStr;
 enum KeyType {
     Accounts(Vec<u8>),
     Contract,
-    Proof(Vec<u8>),
     Unknown,
 }
 
 pub fn construct_contract_key(suffix: EthConnectorStorageId) -> Vec<u8> {
     bytes_to_key(KeyPrefix::EthConnector, &[u8::from(suffix)])
-}
-
-pub fn prefix_proof_key() -> Vec<u8> {
-    construct_contract_key(EthConnectorStorageId::UsedEvent)
 }
 
 pub fn prefix_account_key() -> Vec<u8> {
@@ -52,7 +47,6 @@ pub fn parse<P: AsRef<Path>>(json_file: P, output: Option<P>) -> anyhow::Result<
     println!("Data size: {:.3} Gb", data.len() as f64 / 1_000_000_000.);
     println!("Data values: {:#?}", json_data.result.values.len());
 
-    let mut proofs: Vec<String> = vec![];
     let mut accounts: HashMap<AccountId, NEP141Wei> = HashMap::new();
     let mut contract_data: FungibleToken = FungibleToken::default();
 
@@ -61,11 +55,6 @@ pub fn parse<P: AsRef<Path>>(json_file: P, output: Option<P>) -> anyhow::Result<
             .map_err(|e| anyhow::anyhow!("Failed deserialize key, {e}"))?;
         // Get proofs
         match key_type(&key) {
-            KeyType::Proof(value) => {
-                let proof = String::from_utf8(value)
-                    .map_err(|e| anyhow::anyhow!("Failed parse proof, {e}"))?;
-                proofs.push(proof);
-            }
             KeyType::Accounts(value) => {
                 let account_str = std::str::from_utf8(&value)
                     .map_err(|e| anyhow::anyhow!("Failed parse account to str, {e}"))?;
@@ -89,14 +78,12 @@ pub fn parse<P: AsRef<Path>>(json_file: P, output: Option<P>) -> anyhow::Result<
             KeyType::Unknown => (), //anyhow::bail!("Unknown key type"),
         }
     }
-    println!("Proofs: {}", proofs.len());
     println!("Accounts: {}", accounts.len());
 
     // Store result data
     StateData {
         contract_data,
         accounts,
-        proofs,
     }
     .try_to_vec()
     .and_then(|data| std::fs::write(result_file_name, data))
@@ -104,11 +91,7 @@ pub fn parse<P: AsRef<Path>>(json_file: P, output: Option<P>) -> anyhow::Result<
 }
 
 fn key_type(key: &[u8]) -> KeyType {
-    if is_prefix_proof_key(key) {
-        let proof_prefix_len = prefix_proof_key().len();
-        let value = key[proof_prefix_len..].to_vec();
-        KeyType::Proof(value)
-    } else if is_account_prefix_key(key) {
+    if is_account_prefix_key(key) {
         let account_prefix_len = prefix_account_key().len();
         let value = key[account_prefix_len..].to_vec();
         KeyType::Accounts(value)
@@ -117,11 +100,6 @@ fn key_type(key: &[u8]) -> KeyType {
     } else {
         KeyType::Unknown
     }
-}
-
-fn is_prefix_proof_key(key: &[u8]) -> bool {
-    let proof_prefix = &prefix_proof_key();
-    key.len() > proof_prefix.len() && &key[..proof_prefix.len()] == proof_prefix
 }
 
 fn is_account_prefix_key(key: &[u8]) -> bool {


### PR DESCRIPTION
Handle changes in the migration logic introduced here https://github.com/Near-One/aurora-eth-connector/pull/80.
* Removed proofs 
* Added `total_stuck_supply` to store the total balance for accounts with invalid format.
* Added combine command to combine the indexed and parsed state data so that we can run the migration command once.

