### PR TITLE
Support check migration command

### DIFF
--- a/scripts/init_eth_connector.json
+++ b/scripts/init_eth_connector.json
@@ -1,6 +1,6 @@
 {
   "prover_account": "eth-connector.node0",
-  "account_with_access_right": "eth-connector.node0",
+  "account_with_access_right": "aurora.node0",
   "owner_id": "eth-connector.node0",
   "min_proof_acceptance_height": 0,
   "eth_custodian_address": "096DE9C2B8A5B8c22cEe3289B101f6960d68E51E",

--- a/scripts/init_eth_connector.json
+++ b/scripts/init_eth_connector.json
@@ -2,6 +2,7 @@
   "prover_account": "eth-connector.node0",
   "account_with_access_right": "eth-connector.node0",
   "owner_id": "eth-connector.node0",
+  "min_proof_acceptance_height": 0,
   "eth_custodian_address": "096DE9C2B8A5B8c22cEe3289B101f6960d68E51E",
   "metadata": {
     "spec": "ft-1.0.0",

--- a/scripts/test_flow.sh
+++ b/scripts/test_flow.sh
@@ -208,6 +208,7 @@ privkey=$(cat $ETH_CONNECTOR_KEY_PATH | jq '.private_key' | tr -d '"')
 echo "$privkey"
 $MIGRATION_TOOL migrate --file res_state.borsh --account "$ETH_CONNECTOR_ACCOUNT" --key "$privkey"
 
+sleep 10
 echo "Check migration"
 $MIGRATION_TOOL check-migration --file res_state.borsh --account "$ETH_CONNECTOR_ACCOUNT" --key "$privkey"
 

--- a/scripts/test_flow.sh
+++ b/scripts/test_flow.sh
@@ -15,7 +15,7 @@
 # Init variables
 export NEARCORE_HOME="/tmp/localnet"
 
-AURORA_LAST_VERSION="3.3.1"
+AURORA_LAST_VERSION="3.6.3"
 USER_BASE_BIN=$(python3 -m site --user-base)/bin
 ENGINE_LAST_WASM_URL="https://github.com/aurora-is-near/aurora-engine/releases/download/$AURORA_LAST_VERSION/aurora-mainnet.wasm"
 ENGINE_WASM="/tmp/aurora-contract/target/wasm32-unknown-unknown/release/aurora_engine.wasm"
@@ -207,6 +207,9 @@ echo "Migrate data to Eth-Connector"
 privkey=$(cat $ETH_CONNECTOR_KEY_PATH | jq '.private_key' | tr -d '"')
 echo "$privkey"
 $MIGRATION_TOOL migrate --file res_state.borsh --account "$ETH_CONNECTOR_ACCOUNT" --key "$privkey"
+
+echo "Check migration"
+$MIGRATION_TOOL check-migration --file res_state.borsh --account "$ETH_CONNECTOR_ACCOUNT" --key "$privkey"
 
 echo "Get migrated balance"
 near view $ETH_CONNECTOR_ACCOUNT ft_balance_of  '{"account_id": "test_account.near"}' --keyPath $ETH_CONNECTOR_KEY_PATH --network_id localnet --nodeUrl  http://127.0.0.1:3030 || error_exit

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub struct BlockData {
 pub struct FungibleToken {
     pub total_eth_supply_on_near: NEP141Wei,
     pub total_eth_supply_on_aurora: NEP141Wei,
+    pub account_storage_usage: StorageUsage,
 }
 
 #[derive(Debug, Default, BorshSerialize, BorshDeserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,6 +81,23 @@ async fn main() -> anyhow::Result<()> {
                         .required(true),
                 )
         )
+        .subcommand(
+            Command::new("combine-indexed-and-state-data")
+                .about("Combine indexed and state data")
+                .arg(
+                    arg!(--state <FILE> "Path to the state data file in borsh format")
+                        .required(true)
+                        .value_parser(value_parser!(PathBuf)),
+                )
+                .arg(
+                    arg!(--indexed <FILE> "Path to the indexed data file in borsh format")
+                        .required(true),
+                )
+                .arg(
+                    arg!(--output <FILE> "Output file for combined state and indexed data in borsh format")
+                        .required(true),
+                )
+        )
         .get_matches();
 
     println!(

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -139,6 +139,8 @@ impl Migration {
         }
             .try_to_vec()
             .expect("Failed serialize");
+
+        println!("Expected total supply: {:?}",  self.data.total_supply.as_u128() - self.data.total_stuck_supply.as_u128());
         self.check_migration("Contract data:", contract_migration_data, 1)
             .await?;
 

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -116,15 +116,18 @@ impl Migration {
 
     // Checking the correctness and integrity of data, regardless of
     // the migration process
-    async fn check_migration_full(&self, reproducible_data_for_accounts:  Vec<(HashMap<AccountId, Balance>, usize)>) -> anyhow::Result<()> {
+    async fn check_migration_full(
+        &self,
+        reproducible_data_for_accounts: Vec<(HashMap<AccountId, Balance>, usize)>,
+    ) -> anyhow::Result<()> {
         println!();
         for (accounts, counter) in reproducible_data_for_accounts {
             let migration_data = MigrationInputData {
                 accounts: accounts.clone(),
                 total_supply: None,
             }
-                .try_to_vec()
-                .expect("Failed serialize");
+            .try_to_vec()
+            .expect("Failed serialize");
 
             self.check_migration("Accounts:", migration_data, counter)
                 .await?;
@@ -137,10 +140,13 @@ impl Migration {
                 self.data.total_supply.as_u128() - self.data.total_stuck_supply.as_u128(),
             ),
         }
-            .try_to_vec()
-            .expect("Failed serialize");
+        .try_to_vec()
+        .expect("Failed serialize");
 
-        println!("Expected total supply: {:?}",  self.data.total_supply.as_u128() - self.data.total_stuck_supply.as_u128());
+        println!(
+            "Expected total supply: {:?}",
+            self.data.total_supply.as_u128() - self.data.total_stuck_supply.as_u128()
+        );
         self.check_migration("Contract data:", contract_migration_data, 1)
             .await?;
 
@@ -179,7 +185,8 @@ impl Migration {
     /// Check migration
     pub async fn validate_migration(&self) -> anyhow::Result<()> {
         let reproducible_data_for_accounts = self.get_reproducible_data_for_accounts();
-        self.check_migration_full(reproducible_data_for_accounts).await
+        self.check_migration_full(reproducible_data_for_accounts)
+            .await
     }
 
     /// Run migration process
@@ -190,12 +197,13 @@ impl Migration {
             self.commit_migration(
                 migration_data.try_to_vec().expect("Failed serialize"),
                 "Accounts",
-                accounts_count.clone(),
+                *accounts_count,
             )
             .await?;
         }
 
-        self.check_migration_full(reproducible_data_for_accounts).await
+        self.check_migration_full(reproducible_data_for_accounts)
+            .await
     }
 
     /// Prepare indexed data for migration from Indexer data

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -74,6 +74,7 @@ pub fn parse<P: AsRef<Path>>(json_file: P, output: Option<P>) -> anyhow::Result<
             KeyType::Contract => {
                 let val = base64::decode(&result_value.value)
                     .map_err(|e| anyhow::anyhow!("Failed get contract data, {e}"))?;
+
                 contract_data = FungibleToken::try_from_slice(&val)
                     .map_err(|e| anyhow::anyhow!("Failed parse contract data, {e}"))?;
             }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -487,6 +487,7 @@ impl Client {
                 .call(&request)
                 .await
                 .map_err(|err| CommitTx::Commit(format!("{err:?}")));
+
             // Check response and set errors if it needs
             if let Ok(tx_res) = res {
                 // If success - check response status


### PR DESCRIPTION
- Separated the check migration
- Fixed argument parsing for combine-indexed-and-state-data.
- Updated migration-tool to the latest versions of aurora and aurora-eth-connector.
- Fixed test data.


Current unresolved issue:
- Previously, our migration fit into a single block. Now, the migration includes several callbacks. During the migration, we only check that the first command executed successfully without waiting for all the callbacks to complete. Therefore, during the migration check, the data might be outdated simply because not all transactions have completed yet.